### PR TITLE
ECS batching and respect rate limits

### DIFF
--- a/aws/table_aws_ecs_cluster.go
+++ b/aws/table_aws_ecs_cluster.go
@@ -197,6 +197,8 @@ func listEcsClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 		o.StopOnDuplicateToken = true
 	})
 
+	var clusterArns [][]string
+
 	// List call
 	for paginator.HasMorePages() {
 		// apply rate limiting
@@ -208,10 +210,20 @@ func listEcsClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 			return nil, err
 		}
 
-		for _, items := range output.ClusterArns {
-			d.StreamListItem(ctx, types.Cluster{
-				ClusterArn: aws.String(items),
-			})
+		if len(output.ClusterArns) != 0 {
+			clusterArns = append(clusterArns, output.ClusterArns)
+		}
+	}
+
+	for _, arns := range clusterArns {
+		result, err := describeEcsClusters(ctx, d, svc, arns)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_ecs_cluster.listEcsClusters", "describe_clusters_api_error", err)
+			return nil, err
+		}
+
+		for _, cluster := range result.Clusters {
+			d.StreamListItem(ctx, cluster)
 
 			// Context can be cancelled due to manual cancellation or the limit has been hit
 			if d.RowsRemaining(ctx) == 0 {
@@ -226,6 +238,11 @@ func listEcsClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 //// HYDRATE FUNCTIONS
 
 func getEcsCluster(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	if h.Item != nil {
+		if cluster, ok := h.Item.(types.Cluster); ok && cluster.ClusterName != nil {
+			return &cluster, nil
+		}
+	}
 
 	var clusterArn string
 	if h.Item != nil {
@@ -242,16 +259,7 @@ func getEcsCluster(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 		return nil, err
 	}
 
-	params := &ecs.DescribeClustersInput{
-		Clusters: []string{clusterArn},
-		Include: []types.ClusterField{
-			types.ClusterFieldAttachments,
-			types.ClusterFieldSettings,
-			types.ClusterFieldStatistics,
-		},
-	}
-
-	op, err := svc.DescribeClusters(ctx, params)
+	op, err := describeEcsClusters(ctx, d, svc, []string{clusterArn})
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_ecs_cluster.getEcsCluster", "api_error", err)
 		return nil, err
@@ -262,6 +270,23 @@ func getEcsCluster(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 	}
 
 	return nil, nil
+}
+
+func describeEcsClusters(ctx context.Context, d *plugin.QueryData, svc *ecs.Client, clusters []string) (*ecs.DescribeClustersOutput, error) {
+	params := &ecs.DescribeClustersInput{
+		Clusters: clusters,
+		Include: []types.ClusterField{
+			types.ClusterFieldAttachments,
+			types.ClusterFieldSettings,
+			types.ClusterFieldStatistics,
+		},
+	}
+
+	if d != nil {
+		d.WaitForListRateLimit(ctx)
+	}
+
+	return svc.DescribeClusters(ctx, params)
 }
 
 func getAwsEcsClusterTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/aws/table_aws_ecs_service.go
+++ b/aws/table_aws_ecs_service.go
@@ -272,12 +272,19 @@ func listEcsServices(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	}
 
 	for _, servicesBatch := range chunkStrings(serviceNames, 10) {
+		if len(servicesBatch) == 0 {
+			continue
+		}
+
 		d.WaitForListRateLimit(ctx)
 
 		result, err := getEcsServices(servicesBatch, cluster.ClusterArn, svc, ctx)
 		if err != nil {
 			plugin.Logger(ctx).Error("aws_ecs_service.listEcsServices", "describe_services_api_error", err)
 			return nil, err
+		}
+		if len(result.Services) == 0 {
+			continue
 		}
 
 		for _, service := range result.Services {

--- a/aws/table_aws_ecs_service.go
+++ b/aws/table_aws_ecs_service.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"context"
 	"errors"
-	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
@@ -272,28 +271,15 @@ func listEcsServices(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 		serviceNames = append(serviceNames, output.ServiceArns...)
 	}
 
-	var wg sync.WaitGroup
-	serviceCh := make(chan *ecs.DescribeServicesOutput, len(serviceNames))
-	errorCh := make(chan error, len(serviceNames))
+	for _, servicesBatch := range chunkStrings(serviceNames, 10) {
+		d.WaitForListRateLimit(ctx)
 
-	for _, serviceData := range serviceNames {
-		wg.Add(1)
-		go getServiceDataAsync(serviceData, cluster.ClusterArn, svc, &wg, serviceCh, errorCh, ctx)
-	}
+		result, err := getEcsServices(servicesBatch, cluster.ClusterArn, svc, ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_ecs_service.listEcsServices", "describe_services_api_error", err)
+			return nil, err
+		}
 
-	// wait for all services to be processed
-	wg.Wait()
-
-	// NOTE: close channel before ranging over results
-	close(serviceCh)
-	close(errorCh)
-
-	for err := range errorCh {
-		// return the first error
-		return nil, err
-	}
-
-	for result := range serviceCh {
 		for _, service := range result.Services {
 			d.StreamListItem(ctx, service)
 
@@ -306,21 +292,11 @@ func listEcsServices(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	return nil, nil
 }
 
-func getServiceDataAsync(serviceData string, clusterARN *string, svc *ecs.Client, wg *sync.WaitGroup, serviceCh chan *ecs.DescribeServicesOutput, errorCh chan error, ctx context.Context) {
-	defer wg.Done()
-	rowData, err := getEcsService(serviceData, clusterARN, svc, ctx)
-	if err != nil {
-		errorCh <- err
-	} else if rowData != nil {
-		serviceCh <- rowData
-	}
-}
-
 // Describes the specified services running in your cluster.
 // Below API can describe up to 10 services in a single operation.
-func getEcsService(serviceData string, clusterARN *string, svc *ecs.Client, ctx context.Context) (*ecs.DescribeServicesOutput, error) {
+func getEcsServices(serviceData []string, clusterARN *string, svc *ecs.Client, ctx context.Context) (*ecs.DescribeServicesOutput, error) {
 	params := &ecs.DescribeServicesInput{
-		Services: []string{serviceData},
+		Services: serviceData,
 		Cluster:  clusterARN,
 	}
 	response, err := svc.DescribeServices(ctx, params)
@@ -328,6 +304,24 @@ func getEcsService(serviceData string, clusterARN *string, svc *ecs.Client, ctx 
 		return nil, err
 	}
 	return response, nil
+}
+
+func chunkStrings(items []string, size int) [][]string {
+	if size <= 0 {
+		return nil
+	}
+
+	chunks := make([][]string, 0, (len(items)+size-1)/size)
+	for i := 0; i < len(items); i += size {
+		end := i + size
+		if end > len(items) {
+			end = len(items)
+		}
+
+		chunks = append(chunks, items[i:end])
+	}
+
+	return chunks
 }
 
 // List api call is not returning the tags for the service, so we need to make a separate api call for getting the tag details

--- a/aws/table_aws_ecs_task.go
+++ b/aws/table_aws_ecs_task.go
@@ -350,6 +350,9 @@ func listEcsTasks(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 		if len(arns) == 0 {
 			continue
 		}
+
+		d.WaitForListRateLimit(ctx)
+
 		input := &ecs.DescribeTasksInput{
 			Cluster: clusterArn,
 			Tasks:   arns,


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Applied rate limiting and batched DescribeClusters calls for listing.
* Returned cluster directly when hydrate item present to avoid API.

**🐛 Bugfixes**
* Handled empty service batches and empty results in listing.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98334961?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->