### PR TITLE
fix: SSM parameter ARN for older versions

### DIFF
--- a/aws/table_aws_ssm_parameter.go
+++ b/aws/table_aws_ssm_parameter.go
@@ -71,7 +71,8 @@ func tableAwsSSMParameter(_ context.Context) *plugin.Table {
 				Name:        "arn",
 				Description: "The Amazon Resource Name (ARN) of the parameter.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("ARN"),
+				Hydrate:     getAwsSSMParameterAkas,
+				Transform:   transform.FromValue(),
 			},
 			{
 				Name:        "data_type",


### PR DESCRIPTION
Older parameters might not have the ARN field set on the describe response so we'll use the AKAS builder instead.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed ARN retrieval by hydrating akas for SSM parameters older versions.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112749319?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->