### PR TITLE
fix: Deduplicate VPC peerings and Cognito IdPs

### DIFF
--- a/aws/table_aws_cognito_identity_provider.go
+++ b/aws/table_aws_cognito_identity_provider.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
@@ -233,8 +234,29 @@ func getCognitoIdentityProvider(ctx context.Context, d *plugin.QueryData, h *plu
 
 func getCognitoIdentityProviderTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.EqualsQualString(matrixKeyRegion)
-	userPoolId := d.EqualsQualString("user_pool_id")
-	data := h.Item.(identityProviderInfo)
+	var providerName, userPoolId string
+
+	switch item := h.Item.(type) {
+	// List call streams only the provider description and user pool id via identityProviderInfo
+	case identityProviderInfo:
+		if item.ProviderName != nil {
+			providerName = *item.ProviderName
+		}
+		if item.UserPoolId != nil {
+			userPoolId = *item.UserPoolId
+		}
+	case types.IdentityProviderType:
+		if item.ProviderName != nil {
+			providerName = *item.ProviderName
+		}
+		if item.UserPoolId != nil {
+			userPoolId = *item.UserPoolId
+		}
+	}
+
+	if providerName == "" || userPoolId == "" {
+		return nil, fmt.Errorf("error getting Cognito identity provider info")
+	}
 
 	// Get common columns
 	c, err := getCommonColumns(ctx, d, h)
@@ -246,7 +268,7 @@ func getCognitoIdentityProviderTurbotAkas(ctx context.Context, d *plugin.QueryDa
 
 	// Get data for turbot defined properties
 	//arn:aws:cognito-idp:<region>:<account-id>:userpool/<id>/provider/<name>
-	arn := "arn:" + commonColumnData.Partition + ":cognito-idp:" + region + ":" + commonColumnData.AccountId + ":userpool/" + userPoolId + "/provider/" + *data.ProviderName
+	arn := "arn:" + commonColumnData.Partition + ":cognito-idp:" + region + ":" + commonColumnData.AccountId + ":userpool/" + userPoolId + "/provider/" + providerName
 
 	return []string{arn}, nil
 }

--- a/aws/table_aws_vpc_peering_connection.go
+++ b/aws/table_aws_vpc_peering_connection.go
@@ -217,6 +217,7 @@ func listVpcPeeringConnections(ctx context.Context, d *plugin.QueryData, _ *plug
 		o.StopOnDuplicateToken = true
 	})
 
+	region := d.EqualsQualString("region")
 	for paginator.HasMorePages() {
 		// apply rate limiting
 		d.WaitForListRateLimit(ctx)
@@ -228,6 +229,11 @@ func listVpcPeeringConnections(ctx context.Context, d *plugin.QueryData, _ *plug
 		}
 
 		for _, items := range output.VpcPeeringConnections {
+			// Only stream if this region is the requester's region, to avoid cross-region duplicates
+			if items.RequesterVpcInfo != nil && items.RequesterVpcInfo.Region != nil && *items.RequesterVpcInfo.Region != region {
+				continue
+			}
+
 			d.StreamListItem(ctx, items)
 
 			// Context can be cancelled due to manual cancellation or the limit has been hit

--- a/aws/table_aws_vpc_peering_connection.go
+++ b/aws/table_aws_vpc_peering_connection.go
@@ -217,7 +217,7 @@ func listVpcPeeringConnections(ctx context.Context, d *plugin.QueryData, _ *plug
 		o.StopOnDuplicateToken = true
 	})
 
-	region := d.EqualsQualString("region")
+	region := d.EqualsQualString(matrixKeyRegion)
 	for paginator.HasMorePages() {
 		// apply rate limiting
 		d.WaitForListRateLimit(ctx)
@@ -230,7 +230,7 @@ func listVpcPeeringConnections(ctx context.Context, d *plugin.QueryData, _ *plug
 
 		for _, items := range output.VpcPeeringConnections {
 			// Only stream if this region is the requester's region, to avoid cross-region duplicates
-			if items.RequesterVpcInfo != nil && items.RequesterVpcInfo.Region != nil && *items.RequesterVpcInfo.Region != region {
+			if items.RequesterVpcInfo != nil && items.RequesterVpcInfo.Region != nil && *items.RequesterVpcInfo.Region != region && region != "" {
 				continue
 			}
 


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Deduplicated VPC peering connections and respected region qualifier when skipping.
* Fixed Cognito identity provider handling and ensured AKAs built correctly.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/116824133?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->